### PR TITLE
Bump dependencies and audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,48 +1,291 @@
 {
 	"name": "unidays-node",
-	"version": "1.0.20",
+	"version": "1.0.22",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.8.3"
+				"@babel/highlight": "^7.10.4"
+			}
+		},
+		"@babel/core": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
+			"integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.10.5",
+				"@babel/helper-module-transforms": "^7.10.5",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.10.5",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.5",
+				"@babel/types": "^7.10.5",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.19",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"@babel/highlight": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+			"integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.5",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+			"integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.5"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+			"integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.5",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+			"dev": true
+		},
+		"@babel/helpers": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
-		"@babel/highlight": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+		"@babel/parser": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+			"integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+			"dev": true
+		},
+		"@babel/template": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^4.0.0"
-			},
-			"dependencies": {
-				"js-tokens": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-					"dev": true
-				}
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+			"integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.10.5",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/parser": "^7.10.5",
+				"@babel/types": "^7.10.5",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/types": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+			"integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"lodash": "^4.17.19",
+				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@concordance/react": {
@@ -63,63 +306,16 @@
 			}
 		},
 		"@istanbuljs/load-nyc-config": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-			"integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.3.1",
 				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
 				"js-yaml": "^3.13.1",
 				"resolve-from": "^5.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
-				}
 			}
 		},
 		"@istanbuljs/schema": {
@@ -170,9 +366,9 @@
 			}
 		},
 		"@tootallnate/once": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",
-			"integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
 		"@types/color-name": {
@@ -181,19 +377,12 @@
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 			"dev": true
 		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-			"dev": true
-		},
 		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
 			"requires": {
-				"@types/events": "*",
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
@@ -205,9 +394,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
-			"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
+			"version": "14.0.23",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
+			"integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -217,9 +406,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+			"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -228,30 +417,19 @@
 			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
 			"dev": true
 		},
+		"acorn-walk": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+			"dev": true
+		},
 		"agent-base": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-			"integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+			"integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
 			"dev": true,
 			"requires": {
 				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"aggregate-error": {
@@ -265,9 +443,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+			"version": "6.12.3",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+			"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -362,23 +540,6 @@
 			"requires": {
 				"@types/color-name": "^1.1.1",
 				"color-convert": "^2.0.1"
-			},
-			"dependencies": {
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				}
 			}
 		},
 		"anymatch": {
@@ -463,108 +624,66 @@
 			"dev": true
 		},
 		"ava": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-3.5.0.tgz",
-			"integrity": "sha512-o+xq1RgAZrQ7GX5nddTNeYbUDogwlBoa/Hnt+b1ciCLLxSOj5U6ZFblLNBSKwHtP1X/8R06bmzvX47jmlVu9KQ==",
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-3.10.1.tgz",
+			"integrity": "sha512-+w86ZHyFHIGCABi7NUrn/WJMyC+fDj0BSIlFNVS45WDKAD5vxbIiDWeclctxOOc2KDPfQD7tFOURSBz0FBLD0A==",
 			"dev": true,
 			"requires": {
 				"@concordance/react": "^2.0.0",
+				"acorn": "^7.3.1",
+				"acorn-walk": "^7.2.0",
 				"ansi-styles": "^4.2.1",
 				"arrgv": "^1.0.2",
 				"arrify": "^2.0.1",
-				"chalk": "^3.0.0",
-				"chokidar": "^3.3.1",
+				"callsites": "^3.1.0",
+				"chalk": "^4.1.0",
+				"chokidar": "^3.4.0",
 				"chunkd": "^2.0.1",
-				"ci-parallel-vars": "^1.0.0",
-				"clean-stack": "^2.2.0",
+				"ci-info": "^2.0.0",
+				"ci-parallel-vars": "^1.0.1",
 				"clean-yaml-object": "^0.1.0",
 				"cli-cursor": "^3.1.0",
 				"cli-truncate": "^2.1.0",
-				"code-excerpt": "^2.1.1",
+				"code-excerpt": "^3.0.0",
 				"common-path-prefix": "^3.0.0",
-				"concordance": "^4.0.0",
+				"concordance": "^5.0.0",
 				"convert-source-map": "^1.7.0",
 				"currently-unhandled": "^0.4.1",
 				"debug": "^4.1.1",
 				"del": "^5.1.0",
-				"emittery": "^0.5.1",
+				"emittery": "^0.7.0",
 				"equal-length": "^1.0.0",
-				"figures": "^3.1.0",
-				"globby": "^11.0.0",
-				"ignore-by-default": "^1.0.0",
+				"figures": "^3.2.0",
+				"globby": "^11.0.1",
+				"ignore-by-default": "^2.0.0",
 				"import-local": "^3.0.2",
 				"indent-string": "^4.0.0",
-				"is-ci": "^2.0.0",
 				"is-error": "^2.2.2",
-				"is-plain-object": "^3.0.0",
-				"is-promise": "^2.1.0",
+				"is-plain-object": "^3.0.1",
+				"is-promise": "^4.0.0",
 				"lodash": "^4.17.15",
-				"matcher": "^2.1.0",
+				"matcher": "^3.0.0",
 				"md5-hex": "^3.0.1",
+				"mem": "^6.1.0",
 				"ms": "^2.1.2",
-				"ora": "^4.0.3",
-				"p-map": "^3.0.0",
-				"picomatch": "^2.2.1",
+				"ora": "^4.0.4",
+				"p-map": "^4.0.0",
+				"picomatch": "^2.2.2",
 				"pkg-conf": "^3.1.0",
 				"plur": "^4.0.0",
-				"pretty-ms": "^6.0.0",
+				"pretty-ms": "^7.0.0",
 				"read-pkg": "^5.2.0",
 				"resolve-cwd": "^3.0.0",
 				"slash": "^3.0.0",
-				"source-map-support": "^0.5.16",
-				"stack-utils": "^2.0.1",
+				"source-map-support": "^0.5.19",
+				"stack-utils": "^2.0.2",
 				"strip-ansi": "^6.0.0",
 				"supertap": "^1.0.0",
 				"temp-dir": "^2.0.0",
 				"trim-off-newlines": "^1.0.1",
 				"update-notifier": "^4.1.0",
-				"write-file-atomic": "^3.0.1",
-				"yargs": "^15.1.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"clean-stack": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-					"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"write-file-atomic": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-					"dev": true,
-					"requires": {
-						"imurmurhash": "^0.1.4",
-						"is-typedarray": "^1.0.0",
-						"signal-exit": "^3.0.2",
-						"typedarray-to-buffer": "^3.1.5"
-					}
-				}
+				"write-file-atomic": "^3.0.3",
+				"yargs": "^15.4.0"
 			}
 		},
 		"babel-polyfill": {
@@ -598,20 +717,20 @@
 		},
 		"balanced-match": {
 			"version": "1.0.0",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
 		"binary-extensions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
 			"dev": true
 		},
 		"blueimp-md5": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.12.0.tgz",
-			"integrity": "sha512-zo+HIdIhzojv6F1siQPqPFROyVy7C50KzHv/k/Iz+BtvtVzSHXiMXOpq2wCfNkeBqdCv+V8XOV96tsEt2W/3rQ==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.16.0.tgz",
+			"integrity": "sha512-j4nzWIqEFpLSbdhUApHRGDwfXbV8ALhqOn+FY5L6XBdKPAXU9BpGgFSbDsgqogfqPPR9R2WooseWCsfhfEC6uQ==",
 			"dev": true
 		},
 		"boxen": {
@@ -638,21 +757,6 @@
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
 					}
 				},
 				"type-fest": {
@@ -751,25 +855,13 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				}
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
 			}
 		},
 		"chardet": {
@@ -779,9 +871,9 @@
 			"dev": true
 		},
 		"chokidar": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-			"integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+			"integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
 			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.1",
@@ -791,7 +883,7 @@
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
-				"readdirp": "~3.3.0"
+				"readdirp": "~3.4.0"
 			}
 		},
 		"chunkd": {
@@ -807,15 +899,15 @@
 			"dev": true
 		},
 		"ci-parallel-vars": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.0.tgz",
-			"integrity": "sha512-u6dx20FBXm+apMi+5x7UVm6EH7BL1gc4XrcnQewjcB7HWRcor/V5qWc3RG2HwpgDJ26gIi2DSEu3B7sXynAw/g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.1.tgz",
+			"integrity": "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==",
 			"dev": true
 		},
 		"clean-stack": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
-			"integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
 			"dev": true
 		},
 		"clean-yaml-object": {
@@ -840,9 +932,9 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz",
-			"integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
+			"integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
 			"dev": true
 		},
 		"cli-truncate": {
@@ -856,9 +948,9 @@
 			}
 		},
 		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
 			"dev": true
 		},
 		"cliui": {
@@ -894,18 +986,18 @@
 			"dev": true
 		},
 		"code-excerpt": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
-			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
+			"integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
 			"dev": true,
 			"requires": {
 				"convert-to-spaces": "^1.0.1"
 			}
 		},
 		"codecov": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/codecov/-/codecov-3.6.5.tgz",
-			"integrity": "sha512-v48WuDMUug6JXwmmfsMzhCHRnhUf8O3duqXvltaYJKrO1OekZWpB/eH6iIoaxMl8Qli0+u3OxptdsBOYiD7VAQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.1.tgz",
+			"integrity": "sha512-JHWxyPTkMLLJn9SmKJnwAnvY09kg2Os2+Ux+GG7LwZ9g8gzDDISpIN5wAsH1UBaafA/yGcd3KofMaorE8qd6Lw==",
 			"dev": true,
 			"requires": {
 				"argv": "0.0.2",
@@ -913,21 +1005,33 @@
 				"js-yaml": "3.13.1",
 				"teeny-request": "6.0.1",
 				"urlgrey": "0.4.4"
+			},
+			"dependencies": {
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				}
 			}
 		},
 		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "~1.1.4"
 			}
 		},
 		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
 		"colors": {
@@ -950,38 +1054,24 @@
 		},
 		"concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
 		"concordance": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/concordance/-/concordance-4.0.0.tgz",
-			"integrity": "sha512-l0RFuB8RLfCS0Pt2Id39/oCPykE01pyxgAFypWTlaGRgvLkZrtczZ8atEHpTeEIW+zYWXTBuA9cCSeEOScxReQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.0.tgz",
+			"integrity": "sha512-stOCz9ffg0+rytwTaL2njUOIyMfANwfwmqc9Dr4vTUS/x/KkVFlWx9Zlzu6tHYtjKxxaCF/cEAZgPDac+n35sg==",
 			"dev": true,
 			"requires": {
-				"date-time": "^2.1.0",
-				"esutils": "^2.0.2",
-				"fast-diff": "^1.1.2",
+				"date-time": "^3.1.0",
+				"esutils": "^2.0.3",
+				"fast-diff": "^1.2.0",
 				"js-string-escape": "^1.0.1",
-				"lodash.clonedeep": "^4.5.0",
-				"lodash.flattendeep": "^4.4.0",
-				"lodash.islength": "^4.0.1",
-				"lodash.merge": "^4.6.1",
-				"md5-hex": "^2.0.0",
-				"semver": "^5.5.1",
+				"lodash": "^4.17.15",
+				"md5-hex": "^3.0.1",
+				"semver": "^7.3.2",
 				"well-known-symbols": "^2.0.0"
-			},
-			"dependencies": {
-				"md5-hex": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
-					"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-					"dev": true,
-					"requires": {
-						"md5-o-matic": "^0.1.1"
-					}
-				}
 			}
 		},
 		"configstore": {
@@ -1020,22 +1110,31 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+			"version": "2.6.11",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
 			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"dependencies": {
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		},
 		"crypto-random-string": {
@@ -1054,9 +1153,9 @@
 			}
 		},
 		"date-time": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
-			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
+			"integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
 			"dev": true,
 			"requires": {
 				"time-zone": "^1.0.0"
@@ -1190,6 +1289,15 @@
 						"merge2": "^1.2.3",
 						"slash": "^3.0.0"
 					}
+				},
+				"p-map": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -1233,9 +1341,9 @@
 			"dev": true
 		},
 		"emittery": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.5.1.tgz",
-			"integrity": "sha512-sYZXNHH9PhTfs98ROEFVC3bLiR8KSqXQsEHIwZ9J6H0RaQObC3JYq4G8IvDd0b45/LxfGKYBpmaUN4LiKytaNw==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+			"integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -1269,22 +1377,22 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.4",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-			"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+			"version": "1.17.6",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
+				"is-callable": "^1.2.0",
+				"is-regex": "^1.1.0",
 				"object-inspect": "^1.7.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
+				"string.prototype.trimend": "^1.0.1",
+				"string.prototype.trimstart": "^1.0.1"
 			}
 		},
 		"es-to-primitive": {
@@ -1312,7 +1420,7 @@
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
@@ -1367,6 +1475,62 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						}
+					}
+				},
 				"globals": {
 					"version": "12.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -1376,16 +1540,43 @@
 						"type-fest": "^0.8.1"
 					}
 				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
 				"ignore": {
 					"version": "4.0.6",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 					"dev": true
 				},
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 					"dev": true
 				},
 				"strip-ansi": {
@@ -1398,10 +1589,19 @@
 					}
 				},
 				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				},
 				"type-fest": {
 					"version": "0.8.1",
@@ -1412,9 +1612,9 @@
 			}
 		},
 		"eslint-config-standard": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
-			"integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
+			"integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
 			"dev": true
 		},
 		"eslint-config-standard-jsx": {
@@ -1424,9 +1624,9 @@
 			"dev": true
 		},
 		"eslint-import-resolver-node": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
-			"integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+			"integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.9",
@@ -1447,28 +1647,13 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
 				}
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
-			"integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.9",
@@ -1555,9 +1740,9 @@
 			},
 			"dependencies": {
 				"regexpp": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-					"integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+					"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
 					"dev": true
 				}
 			}
@@ -1605,21 +1790,6 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
 				}
 			}
 		},
@@ -1637,21 +1807,6 @@
 				"semver": "^6.1.0"
 			},
 			"dependencies": {
-				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1691,21 +1846,6 @@
 					"requires": {
 						"esutils": "^2.0.2"
 					}
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
 				}
 			}
 		},
@@ -1716,9 +1856,9 @@
 			"dev": true
 		},
 		"eslint-scope": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-			"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+			"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
@@ -1735,9 +1875,9 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"dev": true
 		},
 		"espree": {
@@ -1758,12 +1898,20 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
-			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "^5.1.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+					"integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+					"dev": true
+				}
 			}
 		},
 		"esrecurse": {
@@ -1782,9 +1930,9 @@
 			"dev": true
 		},
 		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
 		"external-editor": {
@@ -1799,9 +1947,9 @@
 			}
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
 		"fast-diff": {
@@ -1811,9 +1959,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-			"integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+			"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1837,22 +1985,24 @@
 			"dev": true
 		},
 		"fastq": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.1.tgz",
-			"integrity": "sha512-mpIH5sKYueh3YyeJwqtVo8sORi0CgtmkVbK6kZStpQlZBYQuTzG2CZ7idSiJuA7bY0SFCWUc5WIs+oYumGCQNw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
 			}
 		},
 		"fetch-mock": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.3.3.tgz",
-			"integrity": "sha512-MHKcwZ4n9TmnfnVfelUBrrfxtC9tztafIR+F8l/Yu9N+y48fU1BAwj3iSxhYFYELVw73rCZh2DPWtWCekY/t+w==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.7.3.tgz",
+			"integrity": "sha512-I4OkK90JFQnjH8/n3HDtWxH/I6D1wrxoAM2ri+nb444jpuH3RTcgvXx2el+G20KO873W727/66T7QhOvFxNHPg==",
 			"dev": true,
 			"requires": {
 				"babel-polyfill": "^6.26.0",
+				"core-js": "^2.6.9",
 				"glob-to-regexp": "^0.4.0",
+				"lodash.isequal": "^4.5.0",
 				"path-to-regexp": "^2.2.1",
 				"whatwg-url": "^6.5.0"
 			}
@@ -1885,59 +2035,14 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-			"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
 			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
-				"make-dir": "^3.0.0",
+				"make-dir": "^3.0.2",
 				"pkg-dir": "^4.1.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
-					}
-				}
 			}
 		},
 		"find-root": {
@@ -2014,9 +2119,9 @@
 			}
 		},
 		"flatted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
 		},
 		"foreground-child": {
@@ -2027,67 +2132,24 @@
 			"requires": {
 				"cross-spawn": "^7.0.0",
 				"signal-exit": "^3.0.2"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-					"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
 			}
 		},
 		"fromentries": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
-			"integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
+			"integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw==",
 			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
 		"fsevents": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-			"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -2103,10 +2165,22 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
+		"gensync": {
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+			"dev": true
+		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
 		"get-stdin": {
@@ -2153,9 +2227,9 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
@@ -2177,15 +2251,15 @@
 			}
 		},
 		"globals": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
 		},
 		"globby": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-			"integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+			"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
 			"dev": true,
 			"requires": {
 				"array-union": "^2.1.0",
@@ -2216,9 +2290,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 			"dev": true
 		},
 		"graceful-readlink": {
@@ -2243,9 +2317,9 @@
 			}
 		},
 		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true
 		},
 		"has-symbols": {
@@ -2261,19 +2335,19 @@
 			"dev": true
 		},
 		"hasha": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.0.0.tgz",
-			"integrity": "sha512-PqWdhnQhq6tqD32hZv+l1e5mJHNSudjnaAzgAHfkGiU0ABN6lmbZF8abJIulQHbZ7oiHhP8yL6O910ICMc+5pw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
+			"integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
 			"dev": true,
 			"requires": {
-				"is-stream": "^1.1.0",
-				"type-fest": "^0.3.0"
+				"is-stream": "^2.0.0",
+				"type-fest": "^0.8.0"
 			},
 			"dependencies": {
 				"type-fest": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 					"dev": true
 				}
 			}
@@ -2291,9 +2365,9 @@
 			"dev": true
 		},
 		"html-escaper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-			"integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
 		"http-cache-semantics": {
@@ -2311,23 +2385,6 @@
 				"@tootallnate/once": "1",
 				"agent-base": "6",
 				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"https-proxy-agent": {
@@ -2345,21 +2402,6 @@
 					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
 					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
 					"dev": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
 				}
 			}
 		},
@@ -2373,15 +2415,15 @@
 			}
 		},
 		"ignore": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-			"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+			"version": "5.1.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+			"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
 			"dev": true
 		},
 		"ignore-by-default": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-2.0.0.tgz",
+			"integrity": "sha512-+mQSgMRiFD3L3AOxLYOCxjIq4OnAmo5CIuC+lj5ehCJcPtV++QacEV7FdpzvYxH6DaOySWzQU6RR0lPLy37ckA==",
 			"dev": true
 		},
 		"ignore-walk": {
@@ -2441,7 +2483,7 @@
 		},
 		"inflight": {
 			"version": "1.0.6",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
@@ -2450,9 +2492,9 @@
 			}
 		},
 		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
 		"ini": {
@@ -2462,51 +2504,24 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.2.tgz",
+			"integrity": "sha512-DF4osh1FM6l0RJc5YWYhSDB6TawiBRlbV9Cox8MWlidU218Tb7fm3lQTULyUJDfJ0tjbzl0W4q651mrCCEM55w==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",
-				"chalk": "^3.0.0",
+				"chalk": "^4.1.0",
 				"cli-cursor": "^3.1.0",
-				"cli-width": "^2.0.0",
+				"cli-width": "^3.0.0",
 				"external-editor": "^3.0.3",
 				"figures": "^3.0.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.16",
 				"mute-stream": "0.0.8",
 				"run-async": "^2.4.0",
-				"rxjs": "^6.5.3",
+				"rxjs": "^6.6.0",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0",
 				"through": "^2.3.6"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"irregular-plurals": {
@@ -2537,9 +2552,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
 			"dev": true
 		},
 		"is-ci": {
@@ -2585,9 +2600,9 @@
 			}
 		},
 		"is-installed-globally": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.1.tgz",
-			"integrity": "sha512-oiEcGoQbGc+3/iijAijrK2qFpkNoNjsHOm/5V5iaeydyrS/hnwaRCEgH5cpW0P3T1lSjV5piB7S5b5lEugNLhg==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+			"integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
 			"dev": true,
 			"requires": {
 				"global-dirs": "^2.0.1",
@@ -2631,33 +2646,30 @@
 			"dev": true
 		},
 		"is-plain-object": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-			"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-			"dev": true,
-			"requires": {
-				"isobject": "^4.0.0"
-			}
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+			"integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+			"dev": true
 		},
 		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"dev": true
 		},
 		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+			"integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
 		"is-string": {
@@ -2705,12 +2717,6 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
-		"isobject": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-			"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-			"dev": true
-		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
@@ -2727,180 +2733,17 @@
 			}
 		},
 		"istanbul-lib-instrument": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.0.tgz",
-			"integrity": "sha512-Nm4wVHdo7ZXSG30KjZ2Wl5SU/Bw7bDx1PdaiIFzEStdjs0H12mOTncn1GVYuqQSaZxpg87VGBRsVRPGD2cD1AQ==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.7.5",
-				"@babel/parser": "^7.7.5",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
 				"@istanbuljs/schema": "^0.1.2",
 				"istanbul-lib-coverage": "^3.0.0",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
-				"@babel/core": {
-					"version": "7.7.7",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
-					"integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.7.7",
-						"@babel/helpers": "^7.7.4",
-						"@babel/parser": "^7.7.7",
-						"@babel/template": "^7.7.4",
-						"@babel/traverse": "^7.7.4",
-						"@babel/types": "^7.7.4",
-						"convert-source-map": "^1.7.0",
-						"debug": "^4.1.0",
-						"json5": "^2.1.0",
-						"lodash": "^4.17.13",
-						"resolve": "^1.3.2",
-						"semver": "^5.4.1",
-						"source-map": "^0.5.0"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-							"dev": true
-						}
-					}
-				},
-				"@babel/generator": {
-					"version": "7.7.7",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
-					"integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.7.4",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.7.4",
-						"@babel/template": "^7.7.4",
-						"@babel/types": "^7.7.4"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.7.4"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.7.4"
-					}
-				},
-				"@babel/helpers": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
-					"integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
-					"dev": true,
-					"requires": {
-						"@babel/template": "^7.7.4",
-						"@babel/traverse": "^7.7.4",
-						"@babel/types": "^7.7.4"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.7.7",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
-					"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.7.4",
-						"@babel/types": "^7.7.4"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.7.4",
-						"@babel/helper-function-name": "^7.7.4",
-						"@babel/helper-split-export-declaration": "^7.7.4",
-						"@babel/parser": "^7.7.4",
-						"@babel/types": "^7.7.4",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					}
-				},
-				"@babel/types": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"convert-source-map": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-					"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.1"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2924,31 +2767,6 @@
 				"uuid": "^3.3.3"
 			},
 			"dependencies": {
-				"cross-spawn": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-					"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"p-map": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -2956,51 +2774,6 @@
 					"dev": true,
 					"requires": {
 						"aggregate-error": "^3.0.0"
-					}
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-					"dev": true
-				},
-				"rimraf": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-					"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				},
-				"uuid": {
-					"version": "3.3.3",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-					"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-					"dev": true
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
 					}
 				}
 			}
@@ -3014,23 +2787,6 @@
 				"istanbul-lib-coverage": "^3.0.0",
 				"make-dir": "^3.0.0",
 				"supports-color": "^7.1.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"istanbul-lib-source-maps": {
@@ -3042,35 +2798,12 @@
 				"debug": "^4.1.1",
 				"istanbul-lib-coverage": "^3.0.0",
 				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"istanbul-reports": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-			"integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+			"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
 			"dev": true,
 			"requires": {
 				"html-escaper": "^2.0.0",
@@ -3090,9 +2823,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -3130,29 +2863,21 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
+				"minimist": "^1.2.5"
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
-			"integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
+			"integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.0.3",
+				"array-includes": "^3.1.1",
 				"object.assign": "^4.1.0"
 			}
 		},
@@ -3213,9 +2938,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
 			"dev": true
 		},
 		"lodash._baseclone": {
@@ -3230,28 +2955,16 @@
 			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
 			"dev": true
 		},
-		"lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-			"dev": true
-		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
 		},
-		"lodash.islength": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
-			"integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
-			"dev": true
-		},
-		"lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -3267,6 +2980,58 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"loose-envify": {
@@ -3285,18 +3050,18 @@
 			"dev": true
 		},
 		"make-dir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-			"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -3307,19 +3072,28 @@
 			"integrity": "sha1-9M+EV7km7u4qg7FzUBQUvHbrlZc=",
 			"dev": true
 		},
-		"matcher": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/matcher/-/matcher-2.1.0.tgz",
-			"integrity": "sha512-o+nZr+vtJtgPNklyeUKkkH42OsK8WAfdgaJE2FNxcjLPg+5QbeEoT6vRj8Xq/iv18JlQ9cmKsEu0b94ixWf1YQ==",
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^2.0.0"
+				"p-defer": "^1.0.0"
+			}
+		},
+		"matcher": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^4.0.0"
 			},
 			"dependencies": {
 				"escape-string-regexp": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 					"dev": true
 				}
 			}
@@ -3333,16 +3107,28 @@
 				"blueimp-md5": "^2.10.0"
 			}
 		},
-		"md5-o-matic": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-			"dev": true
+		"mem": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-6.1.0.tgz",
+			"integrity": "sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==",
+			"dev": true,
+			"requires": {
+				"map-age-cleaner": "^0.1.3",
+				"mimic-fn": "^3.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.0.0.tgz",
+					"integrity": "sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ==",
+					"dev": true
+				}
+			}
 		},
 		"merge2": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true
 		},
 		"micromatch": {
@@ -3383,26 +3169,18 @@
 			"dev": true
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
-				}
+				"minimist": "^1.2.5"
 			}
 		},
 		"mocha": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.0.tgz",
-			"integrity": "sha512-MymHK8UkU0K15Q/zX7uflZgVoRWiTjy0fXE/QjKts6mowUvGxOdPhZ2qj3b0iZdUrNZlW9LAIMFHB4IW+2b3EQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+			"integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "3.2.3",
@@ -3418,7 +3196,7 @@
 				"js-yaml": "3.13.1",
 				"log-symbols": "3.0.0",
 				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
+				"mkdirp": "0.5.5",
 				"ms": "2.1.1",
 				"node-environment-flags": "1.0.6",
 				"object.assign": "4.1.0",
@@ -3426,8 +3204,8 @@
 				"supports-color": "6.0.0",
 				"which": "1.3.1",
 				"wide-align": "1.1.3",
-				"yargs": "13.3.0",
-				"yargs-parser": "13.1.1",
+				"yargs": "13.3.2",
+				"yargs-parser": "13.1.2",
 				"yargs-unparser": "1.6.0"
 			},
 			"dependencies": {
@@ -3473,6 +3251,21 @@
 						"wrap-ansi": "^5.1.0"
 					}
 				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
 				"debug": {
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -3511,11 +3304,27 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
 				},
 				"locate-path": {
 					"version": "3.0.0",
@@ -3592,9 +3401,9 @@
 					}
 				},
 				"yargs": {
-					"version": "13.3.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-					"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+					"version": "13.3.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
 					"dev": true,
 					"requires": {
 						"cliui": "^5.0.0",
@@ -3606,13 +3415,13 @@
 						"string-width": "^3.0.0",
 						"which-module": "^2.0.0",
 						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.1"
+						"yargs-parser": "^13.1.2"
 					}
 				},
 				"yargs-parser": {
-					"version": "13.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -3653,6 +3462,14 @@
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3",
 				"semver": "^5.7.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"node-fetch": {
@@ -3681,20 +3498,11 @@
 				"validate-npm-package-license": "^3.0.1"
 			},
 			"dependencies": {
-				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
-				},
-				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
 				}
 			}
 		},
@@ -3711,9 +3519,9 @@
 			"dev": true
 		},
 		"nyc": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
-			"integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+			"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
 			"dev": true,
 			"requires": {
 				"@istanbuljs/load-nyc-config": "^1.0.0",
@@ -3724,6 +3532,7 @@
 				"find-cache-dir": "^3.2.0",
 				"find-up": "^4.1.0",
 				"foreground-child": "^2.0.0",
+				"get-package-type": "^0.1.0",
 				"glob": "^7.1.6",
 				"istanbul-lib-coverage": "^3.0.0",
 				"istanbul-lib-hook": "^3.0.0",
@@ -3731,10 +3540,9 @@
 				"istanbul-lib-processinfo": "^2.0.2",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.0.0",
-				"js-yaml": "^3.13.1",
+				"istanbul-reports": "^3.0.2",
 				"make-dir": "^3.0.0",
-				"node-preload": "^0.2.0",
+				"node-preload": "^0.2.1",
 				"p-map": "^3.0.0",
 				"process-on-spawn": "^1.0.0",
 				"resolve-from": "^5.0.0",
@@ -3742,121 +3550,9 @@
 				"signal-exit": "^3.0.2",
 				"spawn-wrap": "^2.0.0",
 				"test-exclude": "^6.0.0",
-				"uuid": "^3.3.3",
 				"yargs": "^15.0.2"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"convert-source-map": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-					"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.1"
-					}
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
 				"p-map": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -3864,93 +3560,6 @@
 					"dev": true,
 					"requires": {
 						"aggregate-error": "^3.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
-				},
-				"rimraf": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-					"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"uuid": {
-					"version": "3.3.3",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-					"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-					"integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
-					"dev": true,
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^16.1.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "16.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-					"integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -3962,9 +3571,9 @@
 			"dev": true
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
 			"dev": true
 		},
 		"object-keys": {
@@ -3986,14 +3595,13 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
-			"integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
+			"integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1",
+				"es-abstract": "^1.17.5",
 				"has": "^1.0.3"
 			}
 		},
@@ -4033,7 +3641,7 @@
 		},
 		"once": {
 			"version": "1.4.0",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/once/-/once-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
@@ -4102,9 +3710,9 @@
 			}
 		},
 		"ora": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-4.0.3.tgz",
-			"integrity": "sha512-fnDebVFyz309A73cqCipVL1fBZewq4vwgSHfxh43vVy31mbyoQ8sCH3Oeaog/owYOs/lLlGVPCISQonTneg6Pg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-4.0.5.tgz",
+			"integrity": "sha512-jCDgm9DqvRcNIAEv2wZPrh7E5PcQiDUnbnWbAfu4NGAE2ZNqPFbDixmWldy1YG2QfLeQhuiu6/h5VRrk6cG50w==",
 			"dev": true,
 			"requires": {
 				"chalk": "^3.0.0",
@@ -4126,21 +3734,6 @@
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
 					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -4156,10 +3749,16 @@
 			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
 			"dev": true
 		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
+		},
 		"p-limit": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
@@ -4175,9 +3774,9 @@
 			}
 		},
 		"p-map": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
 			"dev": true,
 			"requires": {
 				"aggregate-error": "^3.0.0"
@@ -4199,14 +3798,6 @@
 				"hasha": "^5.0.0",
 				"lodash.flattendeep": "^4.4.0",
 				"release-zalgo": "^1.0.0"
-			},
-			"dependencies": {
-				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-					"dev": true
-				}
 			}
 		},
 		"package-json": {
@@ -4262,20 +3853,20 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
 		"path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
 		"path-to-regexp": {
@@ -4291,9 +3882,9 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
 		"pify": {
@@ -4384,9 +3975,9 @@
 			"dev": true
 		},
 		"pretty-ms": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-6.0.1.tgz",
-			"integrity": "sha512-ke4njoVmlotekHlHyCZ3wI/c5AMT8peuHs8rKJqekj/oR5G8lND2dVpicFlUz5cbZgE290vvkMuDwfj/OcW1kw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.0.tgz",
+			"integrity": "sha512-J3aPWiC5e9ZeZFuSeBraGxSkGMOvulSWsxDByOcbD1Pr75YL3LSNIKIb52WXbCLE1sS5s4inBBbryjF4Y05Ceg==",
 			"dev": true,
 			"requires": {
 				"parse-ms": "^2.1.0"
@@ -4456,9 +4047,9 @@
 			}
 		},
 		"react-is": {
-			"version": "16.13.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-			"integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true
 		},
 		"read-pkg": {
@@ -4596,12 +4187,12 @@
 			}
 		},
 		"readdirp": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-			"integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
 			"dev": true,
 			"requires": {
-				"picomatch": "^2.0.7"
+				"picomatch": "^2.2.1"
 			}
 		},
 		"regenerator-runtime": {
@@ -4617,9 +4208,9 @@
 			"dev": true
 		},
 		"registry-auth-token": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
-			"integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
+			"integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
 			"dev": true,
 			"requires": {
 				"rc": "^1.2.8"
@@ -4656,12 +4247,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-cwd": {
@@ -4714,13 +4305,10 @@
 			}
 		},
 		"run-async": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-			"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-			"dev": true,
-			"requires": {
-				"is-promise": "^2.1.0"
-			}
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
 		},
 		"run-parallel": {
 			"version": "1.1.9",
@@ -4729,9 +4317,9 @@
 			"dev": true
 		},
 		"rxjs": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-			"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
+			"integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -4750,9 +4338,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
 			"dev": true
 		},
 		"semver-diff": {
@@ -4785,24 +4373,24 @@
 			"dev": true
 		},
 		"shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "^3.0.0"
 			}
 		},
 		"shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true
 		},
 		"signal-exit": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
 		"slash": {
@@ -4823,27 +4411,19 @@
 			}
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true
 		},
 		"source-map-support": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"spawn-command": {
@@ -4866,29 +4446,6 @@
 				"which": "^2.0.1"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-					"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
 				"which": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4901,9 +4458,9 @@
 			}
 		},
 		"spdx-correct": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -4911,15 +4468,15 @@
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
 			"dev": true
 		},
 		"spdx-expression-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -4939,9 +4496,9 @@
 			"dev": true
 		},
 		"stack-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.1.tgz",
-			"integrity": "sha512-BvBTnHGm8boe+HiJFqP19ywEsGlfQAKqW78pbfvUuzCbUuxPPUyLrH5dYFY+Xn9IpLY3b5ZmMcl8jAqXB4wddg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+			"integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^2.0.0"
@@ -4956,13 +4513,13 @@
 			}
 		},
 		"standard": {
-			"version": "14.3.3",
-			"resolved": "https://registry.npmjs.org/standard/-/standard-14.3.3.tgz",
-			"integrity": "sha512-HBEAD5eVXrr2o/KZ3kU8Wwaxw90wzoq4dOQe6vlRnPoQ6stn4LCLRLBBDp0CjH/aOTL9bDZJbRUOZcBaBnNJ0A==",
+			"version": "14.3.4",
+			"resolved": "https://registry.npmjs.org/standard/-/standard-14.3.4.tgz",
+			"integrity": "sha512-+lpOkFssMkljJ6eaILmqxHQ2n4csuEABmcubLTb9almFi1ElDzXb1819fjf/5ygSyePCq4kU2wMdb2fBfb9P9Q==",
 			"dev": true,
 			"requires": {
 				"eslint": "~6.8.0",
-				"eslint-config-standard": "14.1.0",
+				"eslint-config-standard": "14.1.1",
 				"eslint-config-standard-jsx": "8.1.0",
 				"eslint-plugin-import": "~2.18.0",
 				"eslint-plugin-node": "~10.0.0",
@@ -4973,14 +4530,14 @@
 			}
 		},
 		"standard-engine": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.0.tgz",
-			"integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.1.0.tgz",
+			"integrity": "sha512-DVJnWM1CGkag4ucFLGdiYWa5/kJURPONmMmk17p8FT5NE4UnPZB1vxWnXnRo2sPSL78pWJG8xEM+1Tu19z0deg==",
 			"dev": true,
 			"requires": {
-				"deglob": "^4.0.0",
+				"deglob": "^4.0.1",
 				"get-stdin": "^7.0.0",
-				"minimist": "^1.1.0",
+				"minimist": "^1.2.5",
 				"pkg-conf": "^3.1.0"
 			}
 		},
@@ -5004,24 +4561,24 @@
 				"strip-ansi": "^6.0.0"
 			}
 		},
-		"string.prototype.trimleft": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+		"string.prototype.trimend": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+			"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.17.5"
 			}
 		},
-		"string.prototype.trimright": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+		"string.prototype.trimstart": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+			"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.17.5"
 			}
 		},
 		"strip-ansi": {
@@ -5094,12 +4651,12 @@
 			}
 		},
 		"supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "^4.0.0"
 			}
 		},
 		"table": {
@@ -5133,6 +4690,21 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 					"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+					"dev": true
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
 				"emoji-regex": {
@@ -5214,22 +4786,6 @@
 				"@istanbuljs/schema": "^0.1.2",
 				"glob": "^7.1.4",
 				"minimatch": "^3.0.4"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"text-table": {
@@ -5296,9 +4852,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
 			"dev": true
 		},
 		"type-check": {
@@ -5370,21 +4926,6 @@
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
 					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -5419,9 +4960,9 @@
 			"dev": true
 		},
 		"v8-compile-cache": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -5551,7 +5092,7 @@
 		},
 		"wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://www.myget.org/F/unidays-release/auth/4a06a70f-8e94-4c3a-87f9-00070270bc74/npm/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
@@ -5565,9 +5106,9 @@
 			}
 		},
 		"write-file-atomic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
-			"integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",
@@ -5595,9 +5136,9 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "15.3.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-			"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 			"dev": true,
 			"requires": {
 				"cliui": "^6.0.0",
@@ -5610,13 +5151,13 @@
 				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
-				"yargs-parser": "^18.1.1"
+				"yargs-parser": "^18.1.2"
 			}
 		},
 		"yargs-parser": {
-			"version": "18.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-			"integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",
@@ -5659,6 +5200,21 @@
 						"strip-ansi": "^5.2.0",
 						"wrap-ansi": "^5.1.0"
 					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
 				},
 				"emoji-regex": {
 					"version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unidays-node",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "This is the NodeJS library for integrating with UNiDAYS. This is to be used for coded and codeless integrations. The following documentation provides descriptions of the implementations and examples.",
   "main": "index.js",
   "scripts": {
@@ -11,14 +11,14 @@
   "author": "UNiDAYS",
   "license": "ISC",
   "devDependencies": {
-    "ava": "^3.5.0",
+    "ava": "^3.10.1",
     "co-exec": "^1.1.0",
-    "codecov": "^3.5.0",
-    "fetch-mock": "^7.3.3",
+    "codecov": "^3.7.1",
+    "fetch-mock": "^7.7.3",
     "ghooks": "^2.0.4",
-    "mocha": "^7.1.0",
-    "nyc": "^15.0.0",
-    "standard": "^14.3.3"
+    "mocha": "^7.2.0",
+    "nyc": "^15.1.0",
+    "standard": "^14.3.4"
   },
   "dependencies": {
     "node-fetch": "^2.6.0"


### PR DESCRIPTION
Description of the Change
Bump dependencies in package.json to latest minor and patch for current major
NPM Audit Fix

Benefits
No more security vulnerabilities

Possible Drawbacks
Package incompatibility

Verification Process
Ran test suite and all green:
image
![image](https://user-images.githubusercontent.com/16237974/87918424-520cb800-ca6e-11ea-9413-9292d93c950c.png)

Applicable Issues
n/a