### PR TITLE
bump node-fetch to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "unidays-node",
-	"version": "1.0.22",
+	"version": "1.0.23",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -3473,9 +3473,9 @@
 			}
 		},
 		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-preload": {
 			"version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unidays-node",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "This is the NodeJS library for integrating with UNiDAYS. This is to be used for coded and codeless integrations. The following documentation provides descriptions of the implementations and examples.",
   "main": "index.js",
   "scripts": {
@@ -21,6 +21,6 @@
     "standard": "^14.3.4"
   },
   "dependencies": {
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
### Description of the Change

Bumps `node-fetch` from 2.6.0 -> 2.6.1

### Benefits

Resolves a vulnerability concern

### Possible Drawbacks

Package incompatibility (unlikely, only an increased patch version)

### Verification Process

Ran all tests, all pass.
