### PR TITLE
Resolve ini package vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 </p>
 <br/>
 
-[![Build Status](https://travis-ci.org/MyUNiDAYS/unidays-node.svg?branch=master)](https://travis-ci.org/MyUNiDAYS/unidays-node)
-[![npm version](https://badge.fury.io/js/unidays-node.svg)](https://badge.fury.io/js/unidays-node)
+[![npm version](https://badge.fury.io/js/unidays-node.svg)](https://badge.fury.io/js/unidays-node) [![CircleCI](https://circleci.com/gh/MyUNiDAYS/unidays-node.svg?style=svg)](https://circleci.com/gh/MyUNiDAYS/unidays-node/tree/master)
 
 # UNiDAYS NodeJS Library
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -325,28 +325,28 @@
 			"dev": true
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+			"integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "2.0.3",
+				"@nodelib/fs.stat": "2.0.4",
 				"run-parallel": "^1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+			"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+			"integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.3",
+				"@nodelib/fs.scandir": "2.1.4",
 				"fastq": "^1.6.0"
 			}
 		},
@@ -377,28 +377,6 @@
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 			"dev": true
 		},
-		"@types/glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-			"dev": true,
-			"requires": {
-				"@types/minimatch": "*",
-				"@types/node": "*"
-			}
-		},
-		"@types/minimatch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-			"dev": true
-		},
-		"@types/node": {
-			"version": "14.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
-			"integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
-			"dev": true
-		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -418,9 +396,9 @@
 			"dev": true
 		},
 		"acorn-walk": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.1.tgz",
+			"integrity": "sha512-zn/7dYtoTVkG4EoMU55QlQU4F+m+T7Kren6Vj3C2DapWPnakG/DL9Ns5aPAPW5Ixd3uxXrV/BoMKKVFIazPcdg==",
 			"dev": true
 		},
 		"agent-base": {
@@ -624,20 +602,20 @@
 			"dev": true
 		},
 		"ava": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-3.10.1.tgz",
-			"integrity": "sha512-+w86ZHyFHIGCABi7NUrn/WJMyC+fDj0BSIlFNVS45WDKAD5vxbIiDWeclctxOOc2KDPfQD7tFOURSBz0FBLD0A==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-3.15.0.tgz",
+			"integrity": "sha512-HGAnk1SHPk4Sx6plFAUkzV/XC1j9+iQhOzt4vBly18/yo0AV8Oytx7mtJd/CR8igCJ5p160N/Oo/cNJi2uSeWA==",
 			"dev": true,
 			"requires": {
 				"@concordance/react": "^2.0.0",
-				"acorn": "^7.3.1",
-				"acorn-walk": "^7.2.0",
-				"ansi-styles": "^4.2.1",
+				"acorn": "^8.0.4",
+				"acorn-walk": "^8.0.0",
+				"ansi-styles": "^5.0.0",
 				"arrgv": "^1.0.2",
 				"arrify": "^2.0.1",
 				"callsites": "^3.1.0",
 				"chalk": "^4.1.0",
-				"chokidar": "^3.4.0",
+				"chokidar": "^3.4.3",
 				"chunkd": "^2.0.1",
 				"ci-info": "^2.0.0",
 				"ci-parallel-vars": "^1.0.1",
@@ -646,12 +624,12 @@
 				"cli-truncate": "^2.1.0",
 				"code-excerpt": "^3.0.0",
 				"common-path-prefix": "^3.0.0",
-				"concordance": "^5.0.0",
+				"concordance": "^5.0.1",
 				"convert-source-map": "^1.7.0",
 				"currently-unhandled": "^0.4.1",
-				"debug": "^4.1.1",
-				"del": "^5.1.0",
-				"emittery": "^0.7.0",
+				"debug": "^4.3.1",
+				"del": "^6.0.0",
+				"emittery": "^0.8.0",
 				"equal-length": "^1.0.0",
 				"figures": "^3.2.0",
 				"globby": "^11.0.1",
@@ -659,31 +637,135 @@
 				"import-local": "^3.0.2",
 				"indent-string": "^4.0.0",
 				"is-error": "^2.2.2",
-				"is-plain-object": "^3.0.1",
+				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.20",
 				"matcher": "^3.0.0",
 				"md5-hex": "^3.0.1",
-				"mem": "^6.1.0",
-				"ms": "^2.1.2",
-				"ora": "^4.0.4",
+				"mem": "^8.0.0",
+				"ms": "^2.1.3",
+				"ora": "^5.2.0",
+				"p-event": "^4.2.0",
 				"p-map": "^4.0.0",
 				"picomatch": "^2.2.2",
 				"pkg-conf": "^3.1.0",
 				"plur": "^4.0.0",
-				"pretty-ms": "^7.0.0",
+				"pretty-ms": "^7.0.1",
 				"read-pkg": "^5.2.0",
 				"resolve-cwd": "^3.0.0",
 				"slash": "^3.0.0",
 				"source-map-support": "^0.5.19",
-				"stack-utils": "^2.0.2",
+				"stack-utils": "^2.0.3",
 				"strip-ansi": "^6.0.0",
-				"supertap": "^1.0.0",
+				"supertap": "^2.0.0",
 				"temp-dir": "^2.0.0",
 				"trim-off-newlines": "^1.0.1",
-				"update-notifier": "^4.1.0",
+				"update-notifier": "^5.0.1",
 				"write-file-atomic": "^3.0.3",
-				"yargs": "^15.4.0"
+				"yargs": "^16.2.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.0.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
+					"integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.0.0.tgz",
+					"integrity": "sha512-6564t0m0fuQMnockqBv7wJxo9T5C2V9JpYXyNScfRDPVLusOQQhkpMGrFC17QbiolraQ1sMXX+Y5nJpjqozL4g==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+							"dev": true
+						}
+					}
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.3.0",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+							"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^2.0.1"
+							}
+						}
+					}
+				},
+				"y18n": {
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+					"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "20.2.4",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+					"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+					"dev": true
+				}
 			}
 		},
 		"babel-polyfill": {
@@ -721,16 +803,33 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true
+		},
 		"binary-extensions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
 			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
 			"dev": true
 		},
+		"bl": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+			"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
 		"blueimp-md5": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.16.0.tgz",
-			"integrity": "sha512-j4nzWIqEFpLSbdhUApHRGDwfXbV8ALhqOn+FY5L6XBdKPAXU9BpGgFSbDsgqogfqPPR9R2WooseWCsfhfEC6uQ==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+			"integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q==",
 			"dev": true
 		},
 		"boxen": {
@@ -792,6 +891,16 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
+		"buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -814,9 +923,9 @@
 			},
 			"dependencies": {
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -871,19 +980,28 @@
 			"dev": true
 		},
 		"chokidar": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
-			"integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.0.tgz",
+			"integrity": "sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==",
 			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.1.2",
+				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
-				"readdirp": "~3.4.0"
+				"readdirp": "~3.5.0"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+					"integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+					"dev": true,
+					"optional": true
+				}
 			}
 		},
 		"chunkd": {
@@ -917,9 +1035,9 @@
 			"dev": true
 		},
 		"cli-boxes": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
 			"dev": true
 		},
 		"cli-cursor": {
@@ -932,9 +1050,9 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
-			"integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
+			"integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
 			"dev": true
 		},
 		"cli-truncate": {
@@ -1059,9 +1177,9 @@
 			"dev": true
 		},
 		"concordance": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.0.tgz",
-			"integrity": "sha512-stOCz9ffg0+rytwTaL2njUOIyMfANwfwmqc9Dr4vTUS/x/KkVFlWx9Zlzu6tHYtjKxxaCF/cEAZgPDac+n35sg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.1.tgz",
+			"integrity": "sha512-TbNtInKVElgEBnJ1v2Xg+MFX2lvFLbmlv3EuSC5wTfCwpB8kC3w3mffF6cKuUhkn475Ym1f1I4qmuXzx2+uXpw==",
 			"dev": true,
 			"requires": {
 				"date-time": "^3.1.0",
@@ -1259,46 +1377,19 @@
 			}
 		},
 		"del": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
-			"integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+			"integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
 			"dev": true,
 			"requires": {
-				"globby": "^10.0.1",
-				"graceful-fs": "^4.2.2",
+				"globby": "^11.0.1",
+				"graceful-fs": "^4.2.4",
 				"is-glob": "^4.0.1",
 				"is-path-cwd": "^2.2.0",
-				"is-path-inside": "^3.0.1",
-				"p-map": "^3.0.0",
-				"rimraf": "^3.0.0",
+				"is-path-inside": "^3.0.2",
+				"p-map": "^4.0.0",
+				"rimraf": "^3.0.2",
 				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"globby": {
-					"version": "10.0.2",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-					"integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
-					"dev": true,
-					"requires": {
-						"@types/glob": "^7.1.1",
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.0.3",
-						"glob": "^7.1.3",
-						"ignore": "^5.1.1",
-						"merge2": "^1.2.3",
-						"slash": "^3.0.0"
-					}
-				},
-				"p-map": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"diff": {
@@ -1326,9 +1417,9 @@
 			}
 		},
 		"dot-prop": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-			"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
@@ -1341,9 +1432,9 @@
 			"dev": true
 		},
 		"emittery": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
-			"integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
+			"integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -1410,6 +1501,12 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true
 		},
 		"escape-goat": {
@@ -1985,9 +2082,9 @@
 			"dev": true
 		},
 		"fastq": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
+			"integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -2242,12 +2339,12 @@
 			"dev": true
 		},
 		"global-dirs": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-			"integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+			"integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
 			"dev": true,
 			"requires": {
-				"ini": "^1.3.5"
+				"ini": "1.3.7"
 			}
 		},
 		"globals": {
@@ -2257,9 +2354,9 @@
 			"dev": true
 		},
 		"globby": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-			"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
+			"integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
 			"dev": true,
 			"requires": {
 				"array-union": "^2.1.0",
@@ -2414,6 +2511,12 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true
+		},
 		"ignore": {
 			"version": "5.1.8",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -2498,9 +2601,9 @@
 			"dev": true
 		},
 		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+			"integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
 			"dev": true
 		},
 		"inquirer": {
@@ -2616,9 +2719,9 @@
 			"dev": true
 		},
 		"is-npm": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-			"integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+			"integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
 			"dev": true
 		},
 		"is-number": {
@@ -2646,9 +2749,9 @@
 			"dev": true
 		},
 		"is-plain-object": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-			"integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 			"dev": true
 		},
 		"is-promise": {
@@ -2850,6 +2953,12 @@
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
+		"json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
+		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3049,6 +3158,15 @@
 			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
 			"dev": true
 		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
 		"make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3108,19 +3226,19 @@
 			}
 		},
 		"mem": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-6.1.0.tgz",
-			"integrity": "sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-8.0.0.tgz",
+			"integrity": "sha512-qrcJOe6uD+EW8Wrci1Vdiua/15Xw3n/QnaNXE7varnB6InxSk7nu3/i5jfy3S6kWxr8WYJ6R1o0afMUtvorTsA==",
 			"dev": true,
 			"requires": {
 				"map-age-cleaner": "^0.1.3",
-				"mimic-fn": "^3.0.0"
+				"mimic-fn": "^3.1.0"
 			},
 			"dependencies": {
 				"mimic-fn": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.0.0.tgz",
-					"integrity": "sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+					"integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
 					"dev": true
 				}
 			}
@@ -3710,29 +3828,28 @@
 			}
 		},
 		"ora": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-4.0.5.tgz",
-			"integrity": "sha512-jCDgm9DqvRcNIAEv2wZPrh7E5PcQiDUnbnWbAfu4NGAE2ZNqPFbDixmWldy1YG2QfLeQhuiu6/h5VRrk6cG50w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-5.2.0.tgz",
+			"integrity": "sha512-+wG2v8TUU8EgzPHun1k/n45pXquQ9fHnbXVetl9rRgO6kjZszGGbraF3XPTIdgeA+s1lbRjSEftAnyT0w8ZMvQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^3.0.0",
+				"bl": "^4.0.3",
+				"chalk": "^4.1.0",
 				"cli-cursor": "^3.1.0",
-				"cli-spinners": "^2.2.0",
+				"cli-spinners": "^2.5.0",
 				"is-interactive": "^1.0.0",
-				"log-symbols": "^3.0.0",
-				"mute-stream": "0.0.8",
+				"log-symbols": "^4.0.0",
 				"strip-ansi": "^6.0.0",
 				"wcwidth": "^1.0.1"
 			},
 			"dependencies": {
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+				"log-symbols": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+					"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
+						"chalk": "^4.0.0"
 					}
 				}
 			}
@@ -3753,6 +3870,21 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
 			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
+		},
+		"p-event": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+			"integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+			"dev": true,
+			"requires": {
+				"p-timeout": "^3.1.0"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 			"dev": true
 		},
 		"p-limit": {
@@ -3780,6 +3912,15 @@
 			"dev": true,
 			"requires": {
 				"aggregate-error": "^3.0.0"
+			}
+		},
+		"p-timeout": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"dev": true,
+			"requires": {
+				"p-finally": "^1.0.0"
 			}
 		},
 		"p-try": {
@@ -3975,9 +4116,9 @@
 			"dev": true
 		},
 		"pretty-ms": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.0.tgz",
-			"integrity": "sha512-J3aPWiC5e9ZeZFuSeBraGxSkGMOvulSWsxDByOcbD1Pr75YL3LSNIKIb52WXbCLE1sS5s4inBBbryjF4Y05Ceg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+			"integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
 			"dev": true,
 			"requires": {
 				"parse-ms": "^2.1.0"
@@ -4026,9 +4167,9 @@
 			"dev": true
 		},
 		"pupa": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
-			"integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+			"integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
 			"dev": true,
 			"requires": {
 				"escape-goat": "^2.0.0"
@@ -4065,14 +4206,14 @@
 			},
 			"dependencies": {
 				"parse-json": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -4186,10 +4327,21 @@
 				}
 			}
 		},
+		"readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
+		},
 		"readdirp": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
 			"dev": true,
 			"requires": {
 				"picomatch": "^2.2.1"
@@ -4208,9 +4360,9 @@
 			"dev": true
 		},
 		"registry-auth-token": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
-			"integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+			"integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
 			"dev": true,
 			"requires": {
 				"rc": "^1.2.8"
@@ -4338,10 +4490,13 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-			"dev": true
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"semver-diff": {
 			"version": "3.1.1",
@@ -4361,10 +4516,21 @@
 			}
 		},
 		"serialize-error": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
-			"dev": true
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.13.1"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.13.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+					"dev": true
+				}
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -4496,9 +4662,9 @@
 			"dev": true
 		},
 		"stack-utils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
-			"integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^2.0.0"
@@ -4581,6 +4747,23 @@
 				"es-abstract": "^1.17.5"
 			}
 		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+					"dev": true
+				}
+			}
+		},
 		"strip-ansi": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -4609,45 +4792,16 @@
 			"dev": true
 		},
 		"supertap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",
-			"integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supertap/-/supertap-2.0.0.tgz",
+			"integrity": "sha512-jRzcXlCeDYvKoZGA5oRhYyR3jUIYu0enkSxtmAgHRlD7HwrovTpH4bDSi0py9FtuA8si9cW/fKommJHuaoDHJA==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"indent-string": "^3.2.0",
-				"js-yaml": "^3.10.0",
-				"serialize-error": "^2.1.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"arrify": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-					"dev": true
-				},
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"arrify": "^2.0.1",
+				"indent-string": "^4.0.0",
+				"js-yaml": "^3.14.0",
+				"serialize-error": "^7.0.1",
+				"strip-ansi": "^6.0.0"
 			}
 		},
 		"supports-color": {
@@ -4772,9 +4926,9 @@
 			"dev": true
 		},
 		"term-size": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
-			"integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+			"integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
 			"dev": true
 		},
 		"test-exclude": {
@@ -4897,36 +5051,25 @@
 			}
 		},
 		"update-notifier": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.0.tgz",
-			"integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.0.1.tgz",
+			"integrity": "sha512-BuVpRdlwxeIOvmc32AGYvO1KVdPlsmqSh8KDDBxS6kDE5VR7R8OMP1d8MdhaVBvxl4H3551k9akXr0Y1iIB2Wg==",
 			"dev": true,
 			"requires": {
 				"boxen": "^4.2.0",
-				"chalk": "^3.0.0",
+				"chalk": "^4.1.0",
 				"configstore": "^5.0.1",
 				"has-yarn": "^2.1.0",
 				"import-lazy": "^2.1.0",
 				"is-ci": "^2.0.0",
-				"is-installed-globally": "^0.3.1",
-				"is-npm": "^4.0.0",
+				"is-installed-globally": "^0.3.2",
+				"is-npm": "^5.0.0",
 				"is-yarn-global": "^0.3.0",
-				"latest-version": "^5.0.0",
-				"pupa": "^2.0.1",
+				"latest-version": "^5.1.0",
+				"pupa": "^2.1.1",
+				"semver": "^7.3.2",
 				"semver-diff": "^3.1.1",
 				"xdg-basedir": "^4.0.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				}
 			}
 		},
 		"uri-js": {
@@ -4951,6 +5094,12 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
 			"integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+			"dev": true
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
 		},
 		"uuid": {
@@ -5133,6 +5282,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "unidays-node",
-	"version": "1.0.24",
+	"version": "1.0.25",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "UNiDAYS",
   "license": "ISC",
   "devDependencies": {
-    "ava": "^3.10.1",
+    "ava": "^3.15.0",
     "co-exec": "^1.1.0",
     "codecov": "^3.7.1",
     "fetch-mock": "^7.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unidays-node",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "This is the NodeJS library for integrating with UNiDAYS. This is to be used for coded and codeless integrations. The following documentation provides descriptions of the implementations and examples.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description of the Change

Bumped `ava` dependency version to one which ultimately uses a non-vulnerable version of `ini`

### Benefits

No package vulnerabilities

### Possible Drawbacks

Package incompatibility 

### Verification Process

Ran all tests with npm, all pass ✅

